### PR TITLE
Update Markdown header formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ Project Halligan is the codename for the official BrandMeister Dashboard 2.0
 The official instance of this repository can be found on http://brandmeister.network.
 All other instances have been created by members of the BrandMeister Community.
 
-##Disclaimer
+## Disclaimer
 This repository will only contain stable releases. Since this new dashboard will be interfacing with the selfcare, master servers and give support for sysops to edit their repeaters, we cannot afford it to release unstable builds here.
 This is why all development will be done on a private gitlab server. This repository will be updated as soon as possible when new (stable) builds are released.
 
-##Issue Tracker
+## Issue Tracker
 Please use the issue tracker to report any bugs you find on the dashboard.
 
-##Merge Requests
+## Merge Requests
 Merge requests can be made here too, these will then be moderated and accepted. This means that all merge requests will be pushed to the development repositories so that they will be in the next stable build.
 
-###Language Improvements
+### Language Improvements
 If you've noticed that something is not correct in your language or any other language you speak/know, please create a merge request for this. We would be extremely happy if you could copy the lang/en.json file and translate it in your own language! The more languages the better!
-All language files that have missing translations or do not contain a translation string from the latest stable build will be automatically shown to the user in the default language (english).
+All language files that have missing translations or do not contain a translation string from the latest stable build will be automatically shown to the user in the default language (English).
 
 OR use https://www.transifex.com/maze/brandmeister-dashboard/
 
-##Developers
+## Developers
 [Yentel (ON3YH)](http://on3yh.be) and [Rudy (PD0ZRY)](http://pd0zry.nl)


### PR DESCRIPTION
Add required space after `#` heading markers to make README render cleanly on GitHub.
Capitalize English.